### PR TITLE
Support for parent-child relationship

### DIFF
--- a/goes.go
+++ b/goes.go
@@ -309,6 +309,10 @@ func (c *Connection) Get(index string, documentType string, id string, extraArgs
 // The extraArgs is a list of url.Values that you can send to elasticsearch as
 // URL arguments, for example, to control routing, ttl, version, op_type, etc.
 func (c *Connection) Index(d Document, extraArgs url.Values) (*Response, error) {
+	if parent, ok := d.Parent.(string); ok {
+		extraArgs.Set("parent", parent)
+	}
+
 	r := Request{
 		Conn:      c,
 		Query:     d.Fields,

--- a/goes.go
+++ b/goes.go
@@ -629,3 +629,15 @@ func (c *Connection) OpenIndex(name string) (*Response, error) {
 
 	return r.Run()
 }
+
+func (c *Connection) GetAliases(indexes []string) (*Response, error) {
+
+	r := Request{
+		Conn:      c,
+		IndexList: indexes,
+		method:    "GET",
+		api:       "_alias/",
+	}
+
+	return r.Run()
+}

--- a/goes.go
+++ b/goes.go
@@ -641,3 +641,29 @@ func (c *Connection) GetAliases(indexes []string) (*Response, error) {
 
 	return r.Run()
 }
+
+func (c *Connection) ReplaceIndexInAlias(alias string, old_index string, new_index string) (*Response, error) {
+	command := map[string]interface{}{
+		"actions": make([]map[string]interface{}, 1),
+	}
+
+	command["actions"] = append(command["actions"].([]map[string]interface{}), map[string]interface{}{
+		"remove": map[string]interface{}{
+			"index": old_index,
+			"alias": alias,
+		},
+		"add": map[string]interface{}{
+			"index": new_index,
+			"alias": alias,
+		},
+	})
+
+	r := Request{
+		Conn:   c,
+		Query:  command,
+		method: "POST",
+		api:    "_aliases",
+	}
+
+	return r.Run()
+}

--- a/goes.go
+++ b/goes.go
@@ -605,3 +605,27 @@ func (c *Connection) AliasExists(alias string) (bool, error) {
 
 	return resp.Status == 200, err
 }
+
+// CloseIndex closes an index represented by a name
+func (c *Connection) CloseIndex(name string) (*Response, error) {
+	r := Request{
+		Conn:      c,
+		IndexList: []string{name},
+		method:    "POST",
+		api:       "_close",
+	}
+
+	return r.Run()
+}
+
+// OpenIndex opens an index represented by a name
+func (c *Connection) OpenIndex(name string) (*Response, error) {
+	r := Request{
+		Conn:      c,
+		IndexList: []string{name},
+		method:    "POST",
+		api:       "_open",
+	}
+
+	return r.Run()
+}

--- a/structs.go
+++ b/structs.go
@@ -107,6 +107,7 @@ type Document struct {
 	Id          interface{}
 	BulkCommand string
 	Fields      interface{}
+	Parent      interface{}
 }
 
 // Represents the "items" field in a _bulk response


### PR DESCRIPTION
Hi,

this commit enables you to use parent-child relationships in ElasticSearch. Usage is described here: https://www.elastic.co/guide/en/elasticsearch/guide/current/parent-child.html

There is a test also. Tests are all passing.

**Edit**: Can you please enable "Issues" on the repository? I updated the connector to support ElasticSearch v2.X but it has breaking changes with 1.X so I'd like to discuss it.

Cheers
