### PR TITLE
Make all Request fields public so custom requests can be done

### DIFF
--- a/goes.go
+++ b/goes.go
@@ -46,7 +46,7 @@ func (c *Connection) CreateIndex(name string, mapping interface{}) (*Response, e
 		Conn:      c,
 		Query:     mapping,
 		IndexList: []string{name},
-		method:    "PUT",
+		Method:    "PUT",
 	}
 
 	return r.Run()
@@ -57,7 +57,7 @@ func (c *Connection) DeleteIndex(name string) (*Response, error) {
 	r := Request{
 		Conn:      c,
 		IndexList: []string{name},
-		method:    "DELETE",
+		Method:    "DELETE",
 	}
 
 	return r.Run()
@@ -68,8 +68,8 @@ func (c *Connection) RefreshIndex(name string) (*Response, error) {
 	r := Request{
 		Conn:      c,
 		IndexList: []string{name},
-		method:    "POST",
-		api:       "_refresh",
+		Method:    "POST",
+		API:       "_refresh",
 	}
 
 	return r.Run()
@@ -82,8 +82,8 @@ func (c *Connection) UpdateIndexSettings(name string, settings interface{}) (*Re
 		Conn:      c,
 		Query:     settings,
 		IndexList: []string{name},
-		method:    "PUT",
-		api:       "_settings",
+		Method:    "PUT",
+		API:       "_settings",
 	}
 
 	return r.Run()
@@ -96,8 +96,8 @@ func (c *Connection) Optimize(indexList []string, extraArgs url.Values) (*Respon
 		Conn:      c,
 		IndexList: indexList,
 		ExtraArgs: extraArgs,
-		method:    "POST",
-		api:       "_optimize",
+		Method:    "POST",
+		API:       "_optimize",
 	}
 
 	return r.Run()
@@ -109,8 +109,8 @@ func (c *Connection) Stats(indexList []string, extraArgs url.Values) (*Response,
 		Conn:      c,
 		IndexList: indexList,
 		ExtraArgs: extraArgs,
-		method:    "GET",
-		api:       "_stats",
+		Method:    "GET",
+		API:       "_stats",
 	}
 
 	return r.Run()
@@ -122,8 +122,8 @@ func (c *Connection) IndexStatus(indexList []string) (*Response, error) {
 	r := Request{
 		Conn:      c,
 		IndexList: indexList,
-		method:    "GET",
-		api:       "_status",
+		Method:    "GET",
+		API:       "_status",
 	}
 
 	return r.Run()
@@ -201,9 +201,9 @@ func (c *Connection) BulkSend(documents []Document) (*Response, error) {
 
 	r := Request{
 		Conn:     c,
-		method:   "POST",
-		api:      "_bulk",
-		bulkData: bytes.Join(bulkData, []byte("\n")),
+		Method:   "POST",
+		API:      "_bulk",
+		BulkData: bytes.Join(bulkData, []byte("\n")),
 	}
 
 	return r.Run()
@@ -216,8 +216,8 @@ func (c *Connection) Search(query interface{}, indexList []string, typeList []st
 		Query:     query,
 		IndexList: indexList,
 		TypeList:  typeList,
-		method:    "POST",
-		api:       "_search",
+		Method:    "POST",
+		API:       "_search",
 		ExtraArgs: extraArgs,
 	}
 
@@ -231,8 +231,8 @@ func (c *Connection) Count(query interface{}, indexList []string, typeList []str
 		Query:     query,
 		IndexList: indexList,
 		TypeList:  typeList,
-		method:    "POST",
-		api:       "_count",
+		Method:    "POST",
+		API:       "_count",
 		ExtraArgs: extraArgs,
 	}
 
@@ -248,8 +248,8 @@ func (c *Connection) Query(query interface{}, indexList []string, typeList []str
 		Query:     query,
 		IndexList: indexList,
 		TypeList:  typeList,
-		method:    httpMethod,
-		api:       "_query",
+		Method:    httpMethod,
+		API:       "_query",
 		ExtraArgs: extraArgs,
 	}
 
@@ -268,8 +268,8 @@ func (c *Connection) Scan(query interface{}, indexList []string, typeList []stri
 		Query:     query,
 		IndexList: indexList,
 		TypeList:  typeList,
-		method:    "POST",
-		api:       "_search",
+		Method:    "POST",
+		API:       "_search",
 		ExtraArgs: v,
 	}
 
@@ -283,8 +283,8 @@ func (c *Connection) Scroll(scrollId string, timeout string) (*Response, error) 
 
 	r := Request{
 		Conn:      c,
-		method:    "POST",
-		api:       "_search/scroll",
+		Method:    "POST",
+		API:       "_search/scroll",
 		ExtraArgs: v,
 		Body:      []byte(scrollId),
 	}
@@ -297,8 +297,8 @@ func (c *Connection) Get(index string, documentType string, id string, extraArgs
 	r := Request{
 		Conn:      c,
 		IndexList: []string{index},
-		method:    "GET",
-		api:       documentType + "/" + id,
+		Method:    "GET",
+		API:       documentType + "/" + id,
 		ExtraArgs: extraArgs,
 	}
 
@@ -315,12 +315,12 @@ func (c *Connection) Index(d Document, extraArgs url.Values) (*Response, error) 
 		IndexList: []string{d.Index.(string)},
 		TypeList:  []string{d.Type},
 		ExtraArgs: extraArgs,
-		method:    "POST",
+		Method:    "POST",
 	}
 
 	if d.Id != nil {
-		r.method = "PUT"
-		r.id = d.Id.(string)
+		r.Method = "PUT"
+		r.ID = d.Id.(string)
 	}
 
 	return r.Run()
@@ -335,8 +335,8 @@ func (c *Connection) Delete(d Document, extraArgs url.Values) (*Response, error)
 		IndexList: []string{d.Index.(string)},
 		TypeList:  []string{d.Type},
 		ExtraArgs: extraArgs,
-		method:    "DELETE",
-		id:        d.Id.(string),
+		Method:    "DELETE",
+		ID:        d.Id.(string),
 	}
 
 	return r.Run()
@@ -352,7 +352,7 @@ func (req *Request) Run() (*Response, error) {
 		return esResp, err
 	}
 
-	if req.method != "HEAD" {
+	if req.Method != "HEAD" {
 		err = json.Unmarshal(body, &esResp)
 		if err != nil {
 			return esResp, err
@@ -363,7 +363,7 @@ func (req *Request) Run() (*Response, error) {
 		}
 	}
 
-	if req.api == "_bulk" && esResp.Errors {
+	if req.API == "_bulk" && esResp.Errors {
 		for _, item := range esResp.Items {
 			for _, i := range item {
 				if i.Error != "" {
@@ -387,8 +387,8 @@ func (req *Request) run() ([]byte, uint64, error) {
 	// XXX : refactor this
 	if len(req.Body) > 0 {
 		postData = req.Body
-	} else if req.api == "_bulk" {
-		postData = req.bulkData
+	} else if req.API == "_bulk" {
+		postData = req.BulkData
 	} else {
 		b, err := json.Marshal(req.Query)
 		if err != nil {
@@ -399,12 +399,12 @@ func (req *Request) run() ([]byte, uint64, error) {
 
 	reader := bytes.NewReader(postData)
 
-	newReq, err := http.NewRequest(req.method, req.Url(), reader)
+	newReq, err := http.NewRequest(req.Method, req.Url(), reader)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	if req.method == "POST" || req.method == "PUT" {
+	if req.Method == "POST" || req.Method == "PUT" {
 		newReq.Header.Set("Content-Type", "application/json")
 	}
 
@@ -436,11 +436,11 @@ func (r *Request) Url() string {
 	}
 
 	// XXX : for indexing documents using the normal (non bulk) API
-	if len(r.id) > 0 {
-		path += "/" + r.id
+	if len(r.ID) > 0 {
+		path += "/" + r.ID
 	}
 
-	path += "/" + r.api
+	path += "/" + r.API
 
 	u := url.URL{
 		Scheme:   "http",
@@ -490,8 +490,8 @@ func (c *Connection) PutMapping(typeName string, mapping interface{}, indexes []
 		Conn:      c,
 		Query:     mapping,
 		IndexList: indexes,
-		method:    "PUT",
-		api:       "_mappings/" + typeName,
+		Method:    "PUT",
+		API:       "_mappings/" + typeName,
 	}
 
 	return r.Run()
@@ -502,8 +502,8 @@ func (c *Connection) GetMapping(types []string, indexes []string) (*Response, er
 	r := Request{
 		Conn:      c,
 		IndexList: indexes,
-		method:    "GET",
-		api:       "_mapping/" + strings.Join(types, ","),
+		Method:    "GET",
+		API:       "_mapping/" + strings.Join(types, ","),
 	}
 
 	return r.Run()
@@ -515,7 +515,7 @@ func (c *Connection) IndicesExist(indexes []string) (bool, error) {
 	r := Request{
 		Conn:      c,
 		IndexList: indexes,
-		method:    "HEAD",
+		Method:    "HEAD",
 	}
 
 	resp, err := r.Run()
@@ -530,12 +530,12 @@ func (c *Connection) Update(d Document, query interface{}, extraArgs url.Values)
 		IndexList: []string{d.Index.(string)},
 		TypeList:  []string{d.Type},
 		ExtraArgs: extraArgs,
-		method:    "POST",
-		api:       "_update",
+		Method:    "POST",
+		API:       "_update",
 	}
 
 	if d.Id != nil {
-		r.id = d.Id.(string)
+		r.ID = d.Id.(string)
 	}
 
 	return r.Run()
@@ -547,8 +547,8 @@ func (c *Connection) DeleteMapping(typeName string, indexes []string) (*Response
 	r := Request{
 		Conn:      c,
 		IndexList: indexes,
-		method:    "DELETE",
-		api:       "_mappings/" + typeName,
+		Method:    "DELETE",
+		API:       "_mappings/" + typeName,
 	}
 
 	return r.Run()
@@ -571,8 +571,8 @@ func (c *Connection) modifyAlias(action string, alias string, indexes []string) 
 	r := Request{
 		Conn:   c,
 		Query:  command,
-		method: "POST",
-		api:    "_aliases",
+		Method: "POST",
+		API:    "_aliases",
 	}
 
 	return r.Run()
@@ -593,8 +593,8 @@ func (c *Connection) AliasExists(alias string) (bool, error) {
 
 	r := Request{
 		Conn:   c,
-		method: "HEAD",
-		api:    "_alias/" + alias,
+		Method: "HEAD",
+		API:    "_alias/" + alias,
 	}
 
 	resp, err := r.Run()

--- a/goes_test.go
+++ b/goes_test.go
@@ -67,8 +67,8 @@ func (s *GoesTestSuite) TestUrl(c *C) {
 		Query:     "q",
 		IndexList: []string{"i"},
 		TypeList:  []string{},
-		method:    "GET",
-		api:       "_search",
+		Method:    "GET",
+		API:       "_search",
 	}
 
 	c.Assert(r.Url(), Equals, "http://"+ES_HOST+":"+ES_PORT+"/i/_search")
@@ -83,8 +83,8 @@ func (s *GoesTestSuite) TestUrl(c *C) {
 	r.ExtraArgs.Set("version", "1")
 	c.Assert(r.Url(), Equals, "http://"+ES_HOST+":"+ES_PORT+"/a,b/c,d/_search?version=1")
 
-	r.id = "1234"
-	r.api = ""
+	r.ID = "1234"
+	r.API = ""
 	c.Assert(r.Url(), Equals, "http://"+ES_HOST+":"+ES_PORT+"/a,b/c,d/1234/?version=1")
 }
 
@@ -97,8 +97,8 @@ func (s *GoesTestSuite) TestEsDown(c *C) {
 		Conn:      conn,
 		Query:     query,
 		IndexList: []string{"i"},
-		method:    "GET",
-		api:       "_search",
+		Method:    "GET",
+		API:       "_search",
 	}
 	_, err := r.Run()
 
@@ -114,8 +114,8 @@ func (s *GoesTestSuite) TestRunMissingIndex(c *C) {
 		Conn:      conn,
 		Query:     query,
 		IndexList: []string{"i"},
-		method:    "GET",
-		api:       "_search",
+		Method:    "GET",
+		API:       "_search",
 	}
 	_, err := r.Run()
 

--- a/structs.go
+++ b/structs.go
@@ -37,13 +37,13 @@ type Request struct {
 	TypeList []string
 
 	// HTTP Method to user (GET, POST ...)
-	method string
+	Method string
 
 	// Which api keyword (_search, _bulk, etc) to use
-	api string
+	API string
 
 	// Bulk data
-	bulkData []byte
+	BulkData []byte
 
 	// Request body
 	Body []byte
@@ -52,7 +52,7 @@ type Request struct {
 	ExtraArgs url.Values
 
 	// Used for the id field when indexing a document
-	id string
+	ID string
 }
 
 // Represents a Response from elasticsearch


### PR DESCRIPTION
Currently it's not possible to do requests not explicitly supported by goes. This allows users to make new requests that are not yet implemented.
