### PR TITLE
ES 2 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,31 @@
 language: go
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
+
 go:
-  - 1.5.4
-  - 1.6.3
-  - 1.7.1
+  - 1.6.4
+  - 1.7.5
 
 env:
   global:
-    - GO15VENDOREXPERIMENT=1
+    - JAVA_HOME=/usr/lib/jvm/java-8-oracle
   matrix:
-    - ES_VERSION=1.3.4
-    - ES_VERSION=1.4.4
-    - ES_VERSION=1.5.2
-    - ES_VERSION=1.6.0
-    - ES_VERSION=1.7.0
+    - ES_VERSION=1.7.5 ES_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.5.tar.gz
+    - ES_VERSION=2.4.4 ES_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.4/elasticsearch-2.4.4.tar.gz
+    - ES_VERSION=5.2.0 ES_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.0.tar.gz
 
 before_script:
+  - java -version
+  - echo $JAVA_HOME
   - mkdir ${HOME}/elasticsearch
-  - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - wget $ES_URL
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
-  - "echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml"
-  - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
-  - sleep 10 # Wait for ES to start up
+  - "echo 'script.inline: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml"
+  - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch &
+  - wget --retry-connrefused http://127.0.0.1:9200/ # Wait for ES to start up
 
 install:
   - go get github.com/Masterminds/glide

--- a/goes.go
+++ b/goes.go
@@ -145,7 +145,7 @@ func (c *Client) BulkSend(documents []Document) (*Response, error) {
 
 	// len(documents) * 2 : action + optional_sources
 	// + 1 : room for the trailing \n
-	bulkData := make([][]byte, len(documents)*2+1)
+	bulkData := make([][]byte, 0, len(documents)*2+1)
 	i := 0
 
 	for _, doc := range documents {
@@ -161,7 +161,7 @@ func (c *Client) BulkSend(documents []Document) (*Response, error) {
 			return &Response{}, err
 		}
 
-		bulkData[i] = action
+		bulkData = append(bulkData, action)
 		i++
 
 		if doc.Fields != nil {
@@ -187,13 +187,13 @@ func (c *Client) BulkSend(documents []Document) (*Response, error) {
 				return &Response{}, err
 			}
 
-			bulkData[i] = sources
+			bulkData = append(bulkData, sources)
 			i++
 		}
 	}
 
 	// forces an extra trailing \n absolutely necessary for elasticsearch
-	bulkData[len(bulkData)-1] = []byte(nil)
+	bulkData = append(bulkData, []byte(nil))
 
 	r := Request{
 		Method:   "POST",
@@ -445,7 +445,7 @@ func (c *Client) DeleteMapping(typeName string, indexes []string) (*Response, er
 
 func (c *Client) modifyAlias(action string, alias string, indexes []string) (*Response, error) {
 	command := map[string]interface{}{
-		"actions": make([]map[string]interface{}, 1),
+		"actions": make([]map[string]interface{}, 0, 1),
 	}
 
 	for _, index := range indexes {

--- a/goes.go
+++ b/goes.go
@@ -504,6 +504,11 @@ func (c *Client) Update(d Document, query interface{}, extraArgs url.Values) (*R
 
 // DeleteMapping deletes a mapping along with all data in the type
 func (c *Client) DeleteMapping(typeName string, indexes []string) (*Response, error) {
+	if version, err := c.Version(); err != nil {
+		return nil, err
+	} else if version > "2" {
+		return nil, errors.New("Deletion of mappings is not supported in ES 2.x and above.")
+	}
 
 	r := Request{
 		IndexList: indexes,

--- a/goes.go
+++ b/goes.go
@@ -119,8 +119,16 @@ func (c *Client) Optimize(indexList []string, extraArgs url.Values) (*Response, 
 		Method:    "POST",
 		API:       "_optimize",
 	}
+	if version, _ := c.Version(); version > "2.1" {
+		r.API = "_forcemerge"
+	}
 
 	return c.Do(&r)
+}
+
+// ForceMerge is the same as Optimize, but matches the naming of the endpoint as of ES 2.1.0
+func (c *Client) ForceMerge(indexList []string, extraArgs url.Values) (*Response, error) {
+	return c.Optimize(indexList, extraArgs)
 }
 
 // Stats fetches statistics (_stats) for the current elasticsearch server

--- a/goes_test.go
+++ b/goes_test.go
@@ -541,8 +541,7 @@ func (s *GoesTestSuite) TestDelete(c *C) {
 		Version: 2,
 	}
 	response.Raw = nil
-	response.Shards.Total = 0
-	response.Shards.Successful = 0
+	response.Shards = Shard{}
 	c.Assert(response, DeepEquals, expectedResponse)
 
 	response, err = conn.Delete(d, url.Values{})
@@ -558,6 +557,7 @@ func (s *GoesTestSuite) TestDelete(c *C) {
 		Version: 3,
 	}
 	response.Raw = nil
+	response.Shards = Shard{}
 	c.Assert(response, DeepEquals, expectedResponse)
 }
 
@@ -619,8 +619,7 @@ func (s *GoesTestSuite) TestDeleteByQuery(c *C) {
 		Version: 0,
 	}
 	response.Raw = nil
-	response.Shards.Total = 0
-	response.Shards.Successful = 0
+	response.Shards = Shard{}
 	c.Assert(response, DeepEquals, expectedResponse)
 
 	//should be 0 docs after delete by query

--- a/goes_test.go
+++ b/goes_test.go
@@ -391,9 +391,7 @@ func (s *GoesTestSuite) TestIndexWithFieldsInStruct(c *C) {
 		},
 	}
 
-	extraArgs := make(url.Values, 1)
-	extraArgs.Set("ttl", "86400000")
-	response, err := conn.Index(d, extraArgs)
+	response, err := conn.Index(d, nil)
 	c.Assert(err, IsNil)
 
 	expectedResponse := &Response{
@@ -405,6 +403,7 @@ func (s *GoesTestSuite) TestIndexWithFieldsInStruct(c *C) {
 	}
 
 	response.Raw = nil
+	response.Shards = Shard{}
 	c.Assert(response, DeepEquals, expectedResponse)
 }
 
@@ -428,9 +427,7 @@ func (s *GoesTestSuite) TestIndexWithFieldsNotInMapOrStruct(c *C) {
 		Fields: "test",
 	}
 
-	extraArgs := make(url.Values, 1)
-	extraArgs.Set("ttl", "86400000")
-	_, err = conn.Index(d, extraArgs)
+	_, err = conn.Index(d, nil)
 	c.Assert(err, Not(IsNil))
 }
 

--- a/goes_test.go
+++ b/goes_test.go
@@ -457,9 +457,7 @@ func (s *GoesTestSuite) TestIndexIdDefined(c *C) {
 		},
 	}
 
-	extraArgs := make(url.Values, 1)
-	extraArgs.Set("ttl", "86400000")
-	response, err := conn.Index(d, extraArgs)
+	response, err := conn.Index(d, nil)
 	c.Assert(err, IsNil)
 
 	expectedResponse := &Response{
@@ -471,6 +469,7 @@ func (s *GoesTestSuite) TestIndexIdDefined(c *C) {
 	}
 
 	response.Raw = nil
+	response.Shards = Shard{}
 	c.Assert(response, DeepEquals, expectedResponse)
 }
 

--- a/goes_test.go
+++ b/goes_test.go
@@ -1037,6 +1037,16 @@ func (s *GoesTestSuite) TestAggregations(c *C) {
 			"index.number_of_shards":   1,
 			"index.number_of_replicas": 0,
 		},
+		"mappings": map[string]interface{}{
+			docType: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"user": map[string]interface{}{
+						"type":  "string",
+						"index": "not_analyzed",
+					},
+				},
+			},
+		},
 	}
 
 	defer conn.DeleteIndex(indexName)

--- a/goes_test.go
+++ b/goes_test.go
@@ -1365,6 +1365,10 @@ func (s *GoesTestSuite) TestDeleteMapping(c *C) {
 	time.Sleep(200 * time.Millisecond)
 
 	response, err = conn.DeleteMapping("tweet", []string{indexName})
+	if version, _ := conn.Version(); version > "2" {
+		c.Assert(err, ErrorMatches, ".*not supported.*")
+		return
+	}
 	c.Assert(err, IsNil)
 
 	c.Assert(response.Acknowledged, Equals, true)

--- a/goes_test.go
+++ b/goes_test.go
@@ -5,7 +5,6 @@
 package goes
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -1280,7 +1279,7 @@ func (s *GoesTestSuite) TestUpdate(c *C) {
 	}
 
 	response, err = conn.Update(d, query, extraArgs)
-	fmt.Println(response)
+
 	if err != nil && strings.Contains(err.(*SearchError).Msg, "dynamic scripting") {
 		c.Skip("Scripting is disabled on server, skipping this test")
 		return

--- a/goes_test.go
+++ b/goes_test.go
@@ -115,7 +115,7 @@ func (s *GoesTestSuite) TestRunMissingIndex(c *C) {
 	}
 	_, err := conn.Do(&r)
 
-	c.Assert(err.Error(), Equals, "[404] IndexMissingException[[i] missing]")
+	c.Assert(err.Error(), Matches, "\\[40.\\] .*i.*")
 }
 
 func (s *GoesTestSuite) TestCreateIndex(c *C) {
@@ -1473,7 +1473,7 @@ func (s *GoesTestSuite) TestRemoveAlias(c *C) {
 
 	// Get document via alias
 	_, err = conn.Get(aliasName, docType, docID, url.Values{})
-	c.Assert(err.Error(), Equals, "[404] IndexMissingException[["+aliasName+"] missing]")
+	c.Assert(err.Error(), Matches, "\\[404\\] .*"+aliasName+".*")
 }
 
 func (s *GoesTestSuite) TestAliasExists(c *C) {

--- a/goes_test.go
+++ b/goes_test.go
@@ -817,6 +817,12 @@ func (s *GoesTestSuite) TestCount(c *C) {
 func (s *GoesTestSuite) TestIndexStatus(c *C) {
 	indexName := "testindexstatus"
 	conn := NewClient(ESHost, ESPort)
+
+	// _status endpoint was removed in ES 2.0
+	if version, _ := conn.Version(); version > "2" {
+		return
+	}
+
 	conn.DeleteIndex(indexName)
 
 	mapping := map[string]interface{}{

--- a/goes_test.go
+++ b/goes_test.go
@@ -163,6 +163,7 @@ func (s *GoesTestSuite) TestDeleteIndexExistingIndex(c *C) {
 	indexName := "testdeleteindexexistingindex"
 
 	_, err := conn.CreateIndex(indexName, map[string]interface{}{})
+	defer conn.DeleteIndex(indexName)
 
 	c.Assert(err, IsNil)
 
@@ -181,8 +182,12 @@ func (s *GoesTestSuite) TestUpdateIndexSettings(c *C) {
 	conn := NewClient(ESHost, ESPort)
 	indexName := "testupdateindex"
 
+	// Just in case
+	conn.DeleteIndex(indexName)
+
 	_, err := conn.CreateIndex(indexName, map[string]interface{}{})
 	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(indexName)
 
 	_, err = conn.UpdateIndexSettings(indexName, map[string]interface{}{
 		"index": map[string]interface{}{
@@ -201,6 +206,7 @@ func (s *GoesTestSuite) TestRefreshIndex(c *C) {
 
 	_, err := conn.CreateIndex(indexName, map[string]interface{}{})
 	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(indexName)
 
 	_, err = conn.RefreshIndex(indexName)
 	c.Assert(err, IsNil)
@@ -216,6 +222,7 @@ func (s *GoesTestSuite) TestOptimize(c *C) {
 	conn.DeleteIndex(indexName)
 	_, err := conn.CreateIndex(indexName, map[string]interface{}{})
 	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(indexName)
 
 	// we must wait for a bit otherwise ES crashes
 	time.Sleep(1 * time.Second)
@@ -262,6 +269,7 @@ func (s *GoesTestSuite) TestBulkSend(c *C) {
 	conn.DeleteIndex(indexName)
 	_, err := conn.CreateIndex(indexName, nil)
 	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(indexName)
 
 	response, err := conn.BulkSend(tweets)
 	i := Item{
@@ -352,6 +360,7 @@ func (s *GoesTestSuite) TestStats(c *C) {
 	conn.DeleteIndex(indexName)
 	_, err := conn.CreateIndex(indexName, map[string]interface{}{})
 	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(indexName)
 
 	// we must wait for a bit otherwise ES crashes
 	time.Sleep(1 * time.Second)

--- a/goes_test.go
+++ b/goes_test.go
@@ -151,9 +151,10 @@ func (s *GoesTestSuite) TestDeleteIndexInexistantIndex(c *C) {
 	conn := NewClient(ESHost, ESPort)
 	resp, err := conn.DeleteIndex("foobar")
 
-	c.Assert(err.Error(), Equals, "[404] IndexMissingException[[foobar] missing]")
+	c.Assert(err.Error(), Matches, "\\[404\\] .*foobar.*")
 	resp.Raw = nil // Don't make us have to duplicate this.
-	c.Assert(resp, DeepEquals, &Response{Status: 404, Error: "IndexMissingException[[foobar] missing]"})
+	c.Assert(resp.Status, Equals, uint64(404))
+	c.Assert(resp.Error, Matches, ".*foobar.*")
 }
 
 func (s *GoesTestSuite) TestDeleteIndexExistingIndex(c *C) {

--- a/goes_test.go
+++ b/goes_test.go
@@ -540,6 +540,8 @@ func (s *GoesTestSuite) TestDelete(c *C) {
 		Version: 2,
 	}
 	response.Raw = nil
+	response.Shards.Total = 0
+	response.Shards.Successful = 0
 	c.Assert(response, DeepEquals, expectedResponse)
 
 	response, err = conn.Delete(d, url.Values{})
@@ -616,6 +618,8 @@ func (s *GoesTestSuite) TestDeleteByQuery(c *C) {
 		Version: 0,
 	}
 	response.Raw = nil
+	response.Shards.Total = 0
+	response.Shards.Successful = 0
 	c.Assert(response, DeepEquals, expectedResponse)
 
 	//should be 0 docs after delete by query
@@ -1178,6 +1182,8 @@ func (s *GoesTestSuite) TestUpdate(c *C) {
 	}
 
 	response.Raw = nil
+	response.Shards.Successful = 0
+	response.Shards.Total = 0
 	c.Assert(response, DeepEquals, expectedResponse)
 
 	// Now that we have an ordinary document indexed, try updating it

--- a/request.go
+++ b/request.go
@@ -82,7 +82,7 @@ func (req *Request) Request() (*http.Request, error) {
 		postData = req.Body
 	} else if req.API == "_bulk" {
 		postData = req.BulkData
-	} else {
+	} else if req.Body != nil {
 		b, err := json.Marshal(req.Query)
 		if err != nil {
 			return nil, err
@@ -90,14 +90,12 @@ func (req *Request) Request() (*http.Request, error) {
 		postData = b
 	}
 
-	reader := ioutil.NopCloser(bytes.NewReader(postData))
-
 	newReq, err := http.NewRequest(req.Method, "", nil)
 	if err != nil {
 		return nil, err
 	}
 	newReq.URL = req.URL()
-	newReq.Body = reader
+	newReq.Body = ioutil.NopCloser(bytes.NewReader(postData))
 	newReq.ContentLength = int64(len(postData))
 
 	if req.Method == "POST" || req.Method == "PUT" {

--- a/request.go
+++ b/request.go
@@ -82,7 +82,7 @@ func (req *Request) Request() (*http.Request, error) {
 		postData = req.Body
 	} else if req.API == "_bulk" {
 		postData = req.BulkData
-	} else if req.Body != nil {
+	} else if req.Query != nil {
 		b, err := json.Marshal(req.Query)
 		if err != nil {
 			return nil, err

--- a/structs.go
+++ b/structs.go
@@ -20,6 +20,9 @@ type Client struct {
 	// Client is the http client used to make requests, allowing settings things
 	// such as timeouts etc
 	Client *http.Client
+
+	// Detected version of ES
+	version string
 }
 
 // Response holds an elasticsearch response


### PR DESCRIPTION
At the very least, tests are passing with ElasticSearch 1.7, 2.4, and 5.2!

A couple of methods were updated to work for all three even though the actual ES endpoint changed between versions.

A few methods will no longer work in more recent versions due to removed ES features.

For the most part, the user will still have to know what is supported by the version of ES they are using and write their code accordingly. goes is a relatively thin layer on top of ES and it will likely stay that way, preferring simplicity over magic support for multiple versions without code changes.